### PR TITLE
Don't termintate the process if a device is not found on find method

### DIFF
--- a/lib/pololumaestro.js
+++ b/lib/pololumaestro.js
@@ -329,7 +329,7 @@ POLOLU_VENDOR_ID = 0x1ffb;
 PololuMaestro.find = function(mode, onReady) {
 	if(mode == SERIAL_MODES.UART) {
 		LOG.error("PololuMaestro.find", "UART serial mode is not supported.  Please set your Maestro to use USB Dual Port or USB Chained mode.");
-		process.exit(3);
+		return null;
 	}
 
 	LOG.debug("PololuMaestro.find", "Searching for attached Pololu Maestro...");
@@ -353,7 +353,7 @@ PololuMaestro.find = function(mode, onReady) {
 
 		if(ports.length != 2) {
 			LOG.error("PololuMaestro.find", "Did not find enough serial ports!  Is the Maestro connected and in USB Dual Port mode?");
-			process.exit(3);
+			return null;
 		}
 
 		LOG.debug("PololuMaestro.find", "Found", ports.length, "ports -", ports);

--- a/lib/pololumaestro.js
+++ b/lib/pololumaestro.js
@@ -329,7 +329,7 @@ POLOLU_VENDOR_ID = 0x1ffb;
 PololuMaestro.find = function(mode, onReady) {
 	if(mode == SERIAL_MODES.UART) {
 		LOG.error("PololuMaestro.find", "UART serial mode is not supported.  Please set your Maestro to use USB Dual Port or USB Chained mode.");
-		return null;
+		return false;
 	}
 
 	LOG.debug("PololuMaestro.find", "Searching for attached Pololu Maestro...");
@@ -353,7 +353,7 @@ PololuMaestro.find = function(mode, onReady) {
 
 		if(ports.length != 2) {
 			LOG.error("PololuMaestro.find", "Did not find enough serial ports!  Is the Maestro connected and in USB Dual Port mode?");
-			return null;
+			return false;
 		}
 
 		LOG.debug("PololuMaestro.find", "Found", ports.length, "ports -", ports);
@@ -378,6 +378,7 @@ PololuMaestro.find = function(mode, onReady) {
 		}
 
 		maestro.on("ready", onReady);
+		return true;
 	});
 }
 


### PR DESCRIPTION
- Removing process.exit to avoid inevitable process termination
- Replacing them with return null just so calling methods can realize
  this wasn't successful
