### PR TITLE
Update Node Serialport to latest version and remove old Winston dependency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -124,7 +124,15 @@ PololuMaestro.find(PololuMaestro.SERIAL_MODES.USB_DUAL_PORT, function(error, mae
 });
 ```
 
+You may add a third parameter to the instance declaration to limit the messages sent to the console:  
+`var maestro = new PololuMaestro("COM17", 115200, false);`  
+This sets "debug" messages to not display, cleaning up the console output quite a bit.
+
 ## Version history
+
+ * Node Serialport was updated to the latest version.
+ * Winston was removed because the existing version had security vulnerabilities, and the new version was not a drop in replacement.
+ * A simple `debug` parameter was added to quiet debug logging to the console.
 
 ### v3.0.0
  * Breaking change - the callback for PololuMaestro#find now takes arguments `error, maestro` to be more inline with node conventions

--- a/Readme.md
+++ b/Readme.md
@@ -11,8 +11,6 @@ See the [API documentation](http://omcaree.github.io/node-pololumaestro/) for mo
 
 This module requires [node-serialport](https://github.com/voodootikigod/node-serialport) in order to communicate with the Maestro, this should be installed automatically.
 
-It also uses [Winston](https://github.com/flatiron/winston) for logging.
-
 ## Installation
 
 Install this module with

--- a/lib/logMessages.js
+++ b/lib/logMessages.js
@@ -1,0 +1,1 @@
+module.exports = {debug: true};

--- a/lib/pololumaestro.js
+++ b/lib/pololumaestro.js
@@ -10,7 +10,8 @@ var EventEmitter = require("events").EventEmitter,
 	ChainedModeSerialPortWrapper = require("./serialportwrapper-chained"),
 	SERIAL_MODES = require("./serialmodes"),
 	SerialPort = require("serialport"),
-	TYPES = require("./types");
+	TYPES = require("./types"),
+  logMessages = require("./logMessages");
 
 /**
  * Supports two constructors.  The one you use depends on what mode you have
@@ -38,7 +39,8 @@ var EventEmitter = require("events").EventEmitter,
  *
  * UART mode is not supported.
  */
-var PololuMaestro = function(comPort, baudRate) {
+var PololuMaestro = function(comPort, baudRate, debug = true) {
+	logMessages.debug = debug;
 	if(!comPort && !baudRate) {
 		console.error("PololuMaestro", "Please pass either two COM port addresses (for USB Dual Port mode) or one COM port and one baud rate (for USB Chained mode) into the constructor.");
 
@@ -87,7 +89,9 @@ PololuMaestro.prototype.setTarget = function(channel, us, onComplete) {
 		return;
 	}
 
-	console.debug("PololuMaestro", "Setting channel", channel, "target to", us, "microseconds");
+	if (logMessages.debug) {
+		console.debug("PololuMaestro", "Setting channel", channel, "target to", us, "microseconds");
+	}
 	this._sendCommand(0x84, channel, us * 4, onComplete);
 };
 
@@ -101,7 +105,9 @@ PololuMaestro.prototype.set8BitTarget = function(channel, target, onComplete) {
 		return;
 	}
 
-	console.debug("PololuMaestro", "Setting channel", channel, "8 bit target to", target, "microseconds");
+	if (logMessages.debug) {
+		console.debug("PololuMaestro", "Setting channel", channel, "8 bit target to", target, "microseconds");
+	}
 	this._send8BitCommand(0xFF, channel, target, onComplete);
 };
 
@@ -117,7 +123,9 @@ PololuMaestro.prototype.setSpeed = function(channel, us, onComplete) {
 		return;
 	}
 
-	console.debug("PololuMaestro", "Setting channel", channel, "speed to", us, "microseconds");
+	if (logMessages.debug) {
+		console.debug("PololuMaestro", "Setting channel", channel, "speed to", us, "microseconds");
+	}
 	this._sendCommand(0x87, channel, us, onComplete);
 };
 
@@ -133,7 +141,9 @@ PololuMaestro.prototype.setAcceleration = function(channel, us, onComplete) {
 		return;
 	}
 
-	console.debug("PololuMaestro", "Setting channel", channel, "acceleration to", us, "microseconds");
+	if (logMessages.debug) {
+		console.debug("PololuMaestro", "Setting channel", channel, "acceleration to", us, "microseconds");
+	}
 	this._sendCommand(0x89, channel, us, onComplete);
 };
 
@@ -338,7 +348,9 @@ PololuMaestro.find = function(mode, callback) {
 		return callback(new Error("UART serial mode is not supported.  Please set your Maestro to use USB Dual Port or USB Chained mode."));
 	}
 
-	console.debug("PololuMaestro.find", "Searching for attached Pololu Maestro...");
+	if (logMessages.debug) {
+		console.debug("PololuMaestro.find", "Searching for attached Pololu Maestro...");
+	}
 
 	SerialPort.list(function (error, result) {
 		var ports = [];

--- a/lib/pololumaestro.js
+++ b/lib/pololumaestro.js
@@ -3,8 +3,7 @@
  */
 
 //^ imports
-var LOG = require("winston"),
-	EventEmitter = require("events").EventEmitter,
+var EventEmitter = require("events").EventEmitter,
 	ByteUtils = require("./byteutils"),
 	SerialPortWrapper = require("./serialportwrapper"),
 	DualModeSerialPortWrapper = require("./serialportwrapper-dualport"),
@@ -41,7 +40,7 @@ var LOG = require("winston"),
  */
 var PololuMaestro = function(comPort, baudRate) {
 	if(!comPort && !baudRate) {
-		LOG.error("PololuMaestro", "Please pass either two COM port addresses (for USB Dual Port mode) or one COM port and one baud rate (for USB Chained mode) into the constructor.");
+		console.error("PololuMaestro", "Please pass either two COM port addresses (for USB Dual Port mode) or one COM port and one baud rate (for USB Chained mode) into the constructor.");
 
 		return;
 	}
@@ -49,17 +48,17 @@ var PololuMaestro = function(comPort, baudRate) {
 	if(comPort instanceof SerialPortWrapper) {
 		this._serialPort = comPort;
 	} else if(typeof(comPort) === "string" && typeof(baudRate) == "string") {
-		LOG.info("PololuMaestro", "Using USB Dual Port mode.");
+		console.info("PololuMaestro", "Using USB Dual Port mode.");
 
 		this.mode = SERIAL_MODES.USB_DUAL_PORT;
 		this._serialPort = new DualModeSerialPortWrapper(comPort, baudRate);
 	} else {
 		if(!baudRate) {
-			LOG.info("PololuMaestro", "Defaulting to baud rate of 115200");
+			console.info("PololuMaestro", "Defaulting to baud rate of 115200");
 			baudRate = 115200;
 		}
 
-		LOG.info("PololuMaestro", "Using USB Chained mode.");
+		console.info("PololuMaestro", "Using USB Chained mode.");
 		this.mode = SERIAL_MODES.USB_CHAINED;
 		this._serialPort = new ChainedModeSerialPortWrapper(comPort, baudRate);
 	}
@@ -83,12 +82,12 @@ PololuMaestro.prototype = Object.create(EventEmitter.prototype);
  */
 PololuMaestro.prototype.setTarget = function(channel, us, onComplete) {
 	if(us < 640 || us > 2304) {
-		LOG.error("PololuMaestro", "target value should be 640-2304 microseconds, was: ", us);
+		console.error("PololuMaestro", "target value should be 640-2304 microseconds, was: ", us);
 
 		return;
 	}
 
-	LOG.debug("PololuMaestro", "Setting channel", channel, "target to", us, "microseconds");
+	console.debug("PololuMaestro", "Setting channel", channel, "target to", us, "microseconds");
 	this._sendCommand(0x84, channel, us * 4, onComplete);
 };
 
@@ -97,12 +96,12 @@ PololuMaestro.prototype.setTarget = function(channel, us, onComplete) {
  */
 PololuMaestro.prototype.set8BitTarget = function(channel, target, onComplete) {
 	if(target < 0 || target > 254) {
-		LOG.error("PololuMaestro", "8 bit target value should be 0-254, was:", target);
+		console.error("PololuMaestro", "8 bit target value should be 0-254, was:", target);
 
 		return;
 	}
 
-	LOG.debug("PololuMaestro", "Setting channel", channel, "8 bit target to", target, "microseconds");
+	console.debug("PololuMaestro", "Setting channel", channel, "8 bit target to", target, "microseconds");
 	this._send8BitCommand(0xFF, channel, target, onComplete);
 };
 
@@ -113,12 +112,12 @@ PololuMaestro.prototype.set8BitTarget = function(channel, target, onComplete) {
  */
 PololuMaestro.prototype.setSpeed = function(channel, us, onComplete) {
 	if(us < 0 || us > 255) {
-		LOG.error("PololuMaestro", "speed value should be 0-255, was:", us);
+		console.error("PololuMaestro", "speed value should be 0-255, was:", us);
 
 		return;
 	}
 
-	LOG.debug("PololuMaestro", "Setting channel", channel, "speed to", us, "microseconds");
+	console.debug("PololuMaestro", "Setting channel", channel, "speed to", us, "microseconds");
 	this._sendCommand(0x87, channel, us, onComplete);
 };
 
@@ -129,12 +128,12 @@ PololuMaestro.prototype.setSpeed = function(channel, us, onComplete) {
  */
 PololuMaestro.prototype.setAcceleration = function(channel, us, onComplete) {
 	if(us < 0 || us > 255) {
-		LOG.error("PololuMaestro", "acceleration value should be 0-255, was:", us);
+		console.error("PololuMaestro", "acceleration value should be 0-255, was:", us);
 
 		return;
 	}
 
-	LOG.debug("PololuMaestro", "Setting channel", channel, "acceleration to", us, "microseconds");
+	console.debug("PololuMaestro", "Setting channel", channel, "acceleration to", us, "microseconds");
 	this._sendCommand(0x89, channel, us, onComplete);
 };
 
@@ -180,7 +179,7 @@ PololuMaestro.prototype.reset = function() {
  */
 PololuMaestro.prototype.analogRead = function(channel, onValue) {
 	if(channel > 11) {
-		LOG.error("PololuMaestro", "Only pins 0-11 are analog inputs.");
+		console.error("PololuMaestro", "Only pins 0-11 are analog inputs.");
 
 		return;
 	}
@@ -197,7 +196,7 @@ PololuMaestro.prototype.analogRead = function(channel, onValue) {
  */
 PololuMaestro.prototype.digitalRead = function(channel, onValue) {
 	if(channel < 12) {
-		LOG.error("PololuMaestro", "Only pins 12+ are digital inputs.");
+		console.error("PololuMaestro", "Only pins 12+ are digital inputs.");
 
 		return;
 	}
@@ -276,7 +275,7 @@ PololuMaestro.prototype.restartScriptAtSubroutine = function(subroutineNumber, o
  */
 PololuMaestro.prototype.restartScriptAtSubroutineWithParameter = function(subroutineNumber, parameter, onData) {
 	if(parameter < 0 || parameter > 16383) {
-		LOG.error("PololuMaestro", "Subroutine parameter must be in the range 0-16383");
+		console.error("PololuMaestro", "Subroutine parameter must be in the range 0-16383");
 
 		return;
 	}
@@ -339,7 +338,7 @@ PololuMaestro.find = function(mode, callback) {
 		return callback(new Error("UART serial mode is not supported.  Please set your Maestro to use USB Dual Port or USB Chained mode."));
 	}
 
-	LOG.debug("PololuMaestro.find", "Searching for attached Pololu Maestro...");
+	console.debug("PololuMaestro.find", "Searching for attached Pololu Maestro...");
 
 	SerialPort.list(function (error, result) {
 		var ports = [];
@@ -362,12 +361,12 @@ PololuMaestro.find = function(mode, callback) {
 			return callback(new Error("Did not find enough serial ports!  Is the Maestro connected and in USB Dual Port mode?"));
 		}
 
-		LOG.debug("PololuMaestro.find", "Found", ports.length, "ports -", ports);
+		console.debug("PololuMaestro.find", "Found", ports.length, "ports -", ports);
 
 		var maestro;
 
 		if(mode == SERIAL_MODES.USB_DUAL_PORT) {
-			LOG.info("PololuMaestro.find", "Using command port", ports[0], "and ttl port:", ports[1]);
+			console.info("PololuMaestro.find", "Using command port", ports[0], "and ttl port:", ports[1]);
 
 			// make sure we don't try to reconnect
 			SerialPort.used.push(ports[0]);
@@ -375,7 +374,7 @@ PololuMaestro.find = function(mode, callback) {
 
 			maestro = new PololuMaestro(ports[0], ports[1]);
 		} else {
-			LOG.info("PololuMaestro.find", "Using command port:", ports[0]);
+			console.info("PololuMaestro.find", "Using command port:", ports[0]);
 
 			// make sure we don't try to reconnect
 			SerialPort.used.push(ports[1]);

--- a/lib/serialportwrapper-chained.js
+++ b/lib/serialportwrapper-chained.js
@@ -4,7 +4,6 @@
 
 //^ imports
 var SerialPort = require("serialport"),
-	LOG = require("winston"),
 	SerialPortWrapper = require("./serialportwrapper");
 
 /**
@@ -22,7 +21,7 @@ var SerialPort = require("serialport"),
  */
 var ChainedModeSerialPortWrapper = function(comPort, baudRate) {
 	if(!comPort && !baudRate) {
-		LOG.error("ChainedModeSerialPortWrapper", "No port or baud rate specified.");
+		console.error("ChainedModeSerialPortWrapper", "No port or baud rate specified.");
 
 		return;
 	}
@@ -44,7 +43,7 @@ var ChainedModeSerialPortWrapper = function(comPort, baudRate) {
 	this._serialPort.once("open", function() {
 		this._connected = true;
 
-		LOG.info("ChainedModeSerialPortWrapper", "Connected to " + comPort);
+		console.info("ChainedModeSerialPortWrapper", "Connected to " + comPort);
 
 		this.emit("open");
 	}.bind(this));
@@ -55,7 +54,7 @@ ChainedModeSerialPortWrapper.prototype = Object.create(SerialPortWrapper.prototy
 
 ChainedModeSerialPortWrapper.prototype.writeAndRead = function(bytes, onData) {
 	if(!this._connected) {
-		LOG.warn("ChainedModeSerialPortWrapper", "Not connected yet, deferring read until com port is available.");
+		console.warn("ChainedModeSerialPortWrapper", "Not connected yet, deferring read until com port is available.");
 
 		this.once("open", this.writeAndRead.bind(this, bytes, onData));
 

--- a/lib/serialportwrapper-chained.js
+++ b/lib/serialportwrapper-chained.js
@@ -3,7 +3,7 @@
  */
 
 //^ imports
-var SerialPort = require("serialport").SerialPort,
+var SerialPort = require("serialport"),
 	LOG = require("winston"),
 	SerialPortWrapper = require("./serialportwrapper");
 
@@ -34,7 +34,7 @@ var ChainedModeSerialPortWrapper = function(comPort, baudRate) {
 		this._serialPort = comPort;
 	} else {
 		this._serialPort = new SerialPort(comPort, {
-			baudrate: baudRate,
+			baudRate: baudRate,
 			disconnectedCallback: function() {
 				this.emit("disconnected");
 			}.bind(this)

--- a/lib/serialportwrapper-dualport.js
+++ b/lib/serialportwrapper-dualport.js
@@ -4,7 +4,6 @@
 
 //^ imports
 var SerialPort = require("serialport"),
-	LOG = require("winston"),
 	SerialPortWrapper = require("./serialportwrapper"),
 	async = require("async");
 
@@ -61,7 +60,7 @@ var DualModeSerialPortWrapper = function(controlPort, ttlPort) {
 	], function() {
 		this._connected = true;
 
-		LOG.info("DualModeSerialPortWrapper", "Connected to control port", controlPort, "and ttl port", ttlPort);
+		console.info("DualModeSerialPortWrapper", "Connected to control port", controlPort, "and ttl port", ttlPort);
 
 		this.emit("open");
 	}.bind(this));
@@ -81,7 +80,7 @@ DualModeSerialPortWrapper.prototype._portDisconnected = function() {
 
 DualModeSerialPortWrapper.prototype.writeAndRead = function(bytes, onData) {
 	if(!this._connected) {
-		LOG.warn("DualModeSerialPortWrapper", "Not connected yet, deferring read until com port is available.");
+		console.warn("DualModeSerialPortWrapper", "Not connected yet, deferring read until com port is available.");
 
 		this.once("open", this.writeAndRead.bind(this, bytes, onData));
 
@@ -89,7 +88,7 @@ DualModeSerialPortWrapper.prototype.writeAndRead = function(bytes, onData) {
 	}
 
 	if(this._awaitingRead) {
-		LOG.debug("DualModeSerialPortWrapper", "Deferring write and read of", bytes);
+		console.debug("DualModeSerialPortWrapper", "Deferring write and read of", bytes);
 
 		// defer until the request ahead of us has read from the serial port
 		this.once("read", this.writeAndRead.bind(this, bytes, onData));

--- a/lib/serialportwrapper-dualport.js
+++ b/lib/serialportwrapper-dualport.js
@@ -3,7 +3,7 @@
  */
 
 //^ imports
-var SerialPort = require("serialport").SerialPort,
+var SerialPort = require("serialport"),
 	LOG = require("winston"),
 	SerialPortWrapper = require("./serialportwrapper"),
 	async = require("async");

--- a/lib/serialportwrapper.js
+++ b/lib/serialportwrapper.js
@@ -5,7 +5,8 @@
 //^ imports
 var SerialPort = require("serialport"),
 	EventEmitter = require("events").EventEmitter,
-	ByteUtils = require("./byteutils");
+	ByteUtils = require("./byteutils"),
+  logMessages = require("./logMessages");
 
 /**
  * node-serialport has sychronous writes but asychronous reads. This presents
@@ -36,7 +37,9 @@ var SerialPortWrapper = function() {
 SerialPortWrapper.prototype = Object.create(EventEmitter.prototype);
 
 SerialPortWrapper.prototype.write = function(bytes, onComplete) {
-	console.debug("SerialPortWrapper", "Writing", bytes);
+	if (logMessages.debug) {
+		console.debug("SerialPortWrapper", "Writing", bytes);
+	}
 
 	if(!this._connected) {
 		console.warn("SerialPortWrapper", "Not connected yet, deferring write until com port is available.");

--- a/lib/serialportwrapper.js
+++ b/lib/serialportwrapper.js
@@ -4,7 +4,6 @@
 
 //^ imports
 var SerialPort = require("serialport"),
-	LOG = require("winston"),
 	EventEmitter = require("events").EventEmitter,
 	ByteUtils = require("./byteutils");
 
@@ -37,10 +36,10 @@ var SerialPortWrapper = function() {
 SerialPortWrapper.prototype = Object.create(EventEmitter.prototype);
 
 SerialPortWrapper.prototype.write = function(bytes, onComplete) {
-	LOG.debug("SerialPortWrapper", "Writing", bytes);
+	console.debug("SerialPortWrapper", "Writing", bytes);
 
 	if(!this._connected) {
-		LOG.warn("SerialPortWrapper", "Not connected yet, deferring write until com port is available.");
+		console.warn("SerialPortWrapper", "Not connected yet, deferring write until com port is available.");
 
 		this.once("open", this.write.bind(this, bytes, onComplete));
 
@@ -57,7 +56,7 @@ SerialPortWrapper.prototype.write = function(bytes, onComplete) {
 };
 
 SerialPortWrapper.prototype.writeAndRead = function(bytes, onData) {
-	LOG.error("SerialPortWrapper", "SerialPortWrapper#writeAndRead should be overridden by implementing classes");
+	console.error("SerialPortWrapper", "SerialPortWrapper#writeAndRead should be overridden by implementing classes");
 };
 
 SerialPortWrapper.prototype._write = function(bytes, onComplete) {
@@ -95,7 +94,7 @@ SerialPortWrapper.prototype._readError = function(onComplete) {
 		if(code) {
 			for(var i = 0; i < SERIAL_ERRORS.length; i++) {
 				if(code & SERIAL_ERRORS[i].code) {
-					LOG.warn("SerialPortWrapper", SERIAL_ERRORS[i].message);
+					console.warn("SerialPortWrapper", SERIAL_ERRORS[i].message);
 
 					this.emit("error", code, SERIAL_ERRORS[i].message);
 				}

--- a/lib/serialportwrapper.js
+++ b/lib/serialportwrapper.js
@@ -3,7 +3,7 @@
  */
 
 //^ imports
-var SerialPort = require("serialport").SerialPort,
+var SerialPort = require("serialport"),
 	LOG = require("winston"),
 	EventEmitter = require("events").EventEmitter,
 	ByteUtils = require("./byteutils");

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "serialport": "^9.0.4",
-    "winston": "^0.8",
     "async": "^0.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
   },
   "dependencies": {
     "serialport": "^9.0.4",
-    "async": "^0.9"
+    "async": "^3.2.0"
   },
   "devDependencies": {
-    "nodeunit": "^0.9",
+    "nodeunit": "^0.11.3",
     "jsmockito": "^1.0",
     "jshamcrest": "^0.7",
-    "istanbul": "^0.3",
-    "groc": "^0.7",
-    "proxyquire": "^1.0"
+    "istanbul": "^0.4.5",
+    "groc": "^0.8.0",
+    "proxyquire": "^2.1.3"
   },
   "keywords": [
     "node",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/omcaree/node-pololumaestro.git"
   },
   "dependencies": {
-    "serialport": "^1.2",
+    "serialport": "^9.0.4",
     "winston": "^0.8",
     "async": "^0.9"
   },

--- a/test/byteutils-test.js
+++ b/test/byteutils-test.js
@@ -1,5 +1,4 @@
 var ByteUtils = require("../lib/byteutils"),
-	LOG = require("winston"),
 	JsMockito = require("jsmockito").JsMockito,
 	JsHamcrest = require('jshamcrest').JsHamcrest;
 

--- a/test/pololumaestro-test.js
+++ b/test/pololumaestro-test.js
@@ -18,7 +18,6 @@ var stubs = {
 
 var SerialPortWrapper = require("../lib/serialportwrapper"),
 	SerialModes = require("../lib/serialmodes"),
-	LOG = require("winston"),
 	JsMockito = require("jsmockito").JsMockito,
 	JsHamcrest = require("jshamcrest").JsHamcrest,
 	proxyquire = require("proxyquire");
@@ -80,7 +79,7 @@ module.exports = {
 				output += str + " (0x" + byte.toString(16).toUpperCase() + "), ";
 			});
 
-			LOG.info("TEST: Serial port recieved " + output.substring(0, output.length - 2));
+			console.info("TEST: Serial port recieved " + output.substring(0, output.length - 2));
 
 			// invoke callback
 			if(callback) {
@@ -98,8 +97,8 @@ module.exports = {
 				}
 
 				if(arr_equals(bytes, traffic.input)) {
-					LOG.info("TEST: traffic.input " + traffic.input);
-					LOG.info("TEST: traffic.output " + traffic.output);
+					console.info("TEST: traffic.input " + traffic.input);
+					console.info("TEST: traffic.output " + traffic.output);
 					onData(traffic.output);
 				}
 			});
@@ -193,7 +192,7 @@ module.exports = {
 		var position;
 			
 		this._maestro.getPosition(5, function(data) {
-			LOG.info("getPosition callback saw: " + data);
+			console.info("getPosition callback saw: " + data);
 			position = data;
 		});
 

--- a/test/serialportwrapper-chained-test.js
+++ b/test/serialportwrapper-chained-test.js
@@ -1,6 +1,5 @@
 var ChainedModeSerialPortWrapper = require("../lib/serialportwrapper-chained"),
 	SerialPort = require("serialport"),
-	LOG = require("winston"),
 	JsMockito = require("jsmockito").JsMockito,
 	JsHamcrest = require('jshamcrest').JsHamcrest;
 
@@ -59,7 +58,7 @@ module.exports = {
 				output += str + " (0x" + byte.toString(16).toUpperCase() + "), ";
 			});
 
-			LOG.info("TEST: Serial port recieved " + output.substring(0, output.length - 2));
+			console.info("TEST: Serial port recieved " + output.substring(0, output.length - 2));
 
 			// invoke callback
 			if(callback) {
@@ -70,9 +69,9 @@ module.exports = {
 				if(arr_equals(bytes, traffic.input)) {
 					invocation.output = traffic.output;
 
-					LOG.info("TEST: traffic.input " + traffic.input);
-					LOG.info("TEST: traffic.output " + traffic.output);
-					LOG.info("TEST: emitting data " + traffic.output + " to " + mockSerialPort.listeners("data").length + " listeners");
+					console.info("TEST: traffic.input " + traffic.input);
+					console.info("TEST: traffic.output " + traffic.output);
+					console.info("TEST: emitting data " + traffic.output + " to " + mockSerialPort.listeners("data").length + " listeners");
 					mockSerialPort.emit("data", traffic.output);
 				}
 			});

--- a/test/serialportwrapper-chained-test.js
+++ b/test/serialportwrapper-chained-test.js
@@ -1,5 +1,5 @@
 var ChainedModeSerialPortWrapper = require("../lib/serialportwrapper-chained"),
-	SerialPort = require("serialport").SerialPort,
+	SerialPort = require("serialport"),
 	LOG = require("winston"),
 	JsMockito = require("jsmockito").JsMockito,
 	JsHamcrest = require('jshamcrest').JsHamcrest;

--- a/test/serialportwrapper-dualport-test.js
+++ b/test/serialportwrapper-dualport-test.js
@@ -1,5 +1,5 @@
 var DualModeSerialPortWrapper = require("../lib/serialportwrapper-dualport"),
-	SerialPort = require("serialport").SerialPort,
+	SerialPort = require("serialport"),
 	LOG = require("winston"),
 	JsMockito = require("jsmockito").JsMockito,
 	JsHamcrest = require('jshamcrest').JsHamcrest;

--- a/test/serialportwrapper-dualport-test.js
+++ b/test/serialportwrapper-dualport-test.js
@@ -1,6 +1,5 @@
 var DualModeSerialPortWrapper = require("../lib/serialportwrapper-dualport"),
 	SerialPort = require("serialport"),
-	LOG = require("winston"),
 	JsMockito = require("jsmockito").JsMockito,
 	JsHamcrest = require('jshamcrest').JsHamcrest;
 
@@ -61,7 +60,7 @@ module.exports = {
 				output += str + " (0x" + byte.toString(16).toUpperCase() + "), ";
 			});
 
-			LOG.info("TEST: Serial port recieved " + output.substring(0, output.length - 2));
+			console.info("TEST: Serial port recieved " + output.substring(0, output.length - 2));
 
 			// invoke callback
 			if(callback) {
@@ -87,10 +86,10 @@ module.exports = {
 						data: output
 					};
 
-					LOG.info("TEST: traffic.input " + invocation.arguments[0]);
-					LOG.info("TEST: traffic.output.port " + invocation.output.port);
-					LOG.info("TEST: traffic.output.data " + invocation.output.data);
-					LOG.info("TEST: emitting data to " + target.listeners("data").length + " listeners via " + port + " port");
+					console.info("TEST: traffic.input " + invocation.arguments[0]);
+					console.info("TEST: traffic.output.port " + invocation.output.port);
+					console.info("TEST: traffic.output.data " + invocation.output.data);
+					console.info("TEST: emitting data to " + target.listeners("data").length + " listeners via " + port + " port");
 					target.emit("data", invocation.output.data);
 				}
 			}.bind(this));


### PR DESCRIPTION
This was done with minimal changes. Further changes should probably be made to improve code, but this is enough to get it working.

Using the latest Serialport package is important to avoid bugs found in older versions.

The installed version of Winston was causing error in the current LTS Node.js version. Updating to Winston 3 is non-trivial, and I could not see any benefit to using Winston over just using console.